### PR TITLE
Add an authorization header if the jwt option is passed

### DIFF
--- a/src/pusher-platform.ts
+++ b/src/pusher-platform.ts
@@ -278,6 +278,10 @@ export class BaseClient {
       xhr.setRequestHeader("content-type", "application/json");
     }
 
+    if (options.jwt) {
+      xhr.setRequestHeader("authorization", `Bearer ${options.jwt}`);
+    }
+
     for (let key in options.headers) {
       xhr.setRequestHeader(key, options.headers[key]);
     }


### PR DESCRIPTION
This allows me to pass in a `jwt` token with requests (the options object is supposed to take the `jwt` key according to its interface).

Subscriptions still appear to be broken, though -- they don't seem to be doing anything with the jwt option.