### PR TITLE
Provide a default export and allow partial member imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,16 @@ import { BaseClient } from './base-client';
 import { ResumableSubscription } from './resumable-subscription';
 import { Subscription } from './subscription';
 
-export default { 
-    App,
-    BaseClient,
-    ResumableSubscription,
-    Subscription
-}
+export {
+  App,
+  BaseClient,
+  ResumableSubscription,
+  Subscription,
+};
+
+export default {
+  App,
+  BaseClient,
+  ResumableSubscription,
+  Subscription,
+};


### PR DESCRIPTION
Currently, we have to do the following to use the library:

```javascript
import PusherPlatform from 'pusher-platform-js';

// do something with PusherPlatform.App or other members
```

After this change, you can still import the library in the same way as before, but also do the following:

```javascript
import { App } from 'pusher-platform-js';
```

This is a bit more natural.

This PR does not change how imports/exports are used internally, but it would be more natural for subcriptions.ts (and other files) to export the class as the default export, and then import it directly (`import Subscription from './subscription'` rather than importing it as a member). When importing multiple things, the following syntax works:

```javascript
import defaultMember, { member [ , [...] ] } from 'module-name';
```

See more here: https://mdn.io/import