### PR TITLE
remove "https://" from cluster

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ export default class App {
         this.tokenProvider = options.tokenProvider;
         this.client = options.client || new BaseClient({
             cluster:
-                options.cluster.replace(/^https:\/\//, "") || DEFAULT_CLUSTER,
+                options.cluster.replace(/^https?:\/\//, "") || DEFAULT_CLUSTER,
             encrypted: options.encrypted
         });
         if(options.logger){


### PR DESCRIPTION
### What?

ignore schema in cluster setting

#### Why?

so that it doesn't matter if the consumer includes the schema in their cluster specification

----

CC @pusher/sigsdk @hph 
