### PR TITLE
Updates import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use Webpack.
 Import it with:
 
 ```JavaScript
-import * as PusherPlatform from `pusher-platform`
+import PusherPlatform from `pusher-platform`
 ```
 
 Then you can access all exported classes by calling referencing them from it: `PusherPlatform.App`.


### PR DESCRIPTION
### What?
Updating the README instructions to instantiate a Pusher Platform app
...

#### Why?
The original instructions were incorrect: `import * as PusherPlatform from 'pusher-platform-js'` does not work.  `import PusherPlatform from 'pusher-platform-js'` does
...

#### How?
Removed the asterisk syntax, replaced with default-import syntax
...

----

CC @pusher/sigsdk
