### PR TITLE
Catches for missing serviceId in App options

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,15 @@
 import { TokenProvider } from './token-provider';
 import { BaseClient } from './base-client';
 import { RequestOptions } from './base-client';
+<<<<<<< HEAD
 import { ConsoleLogger, Logger } from './logger';
 import { ResumableSubscribeOptions, ResumableSubscription } from './resumable-subscription';
 import { SubscribeOptions, Subscription } from './subscription';
+=======
+import { Subscription, SubscribeOptions } from './subscription';
+import { ResumableSubscription, ResumableSubscribeOptions } from './resumable-subscription';
+import { DefaultLogger, Logger } from './logger';
+>>>>>>> Catches for missing serviceId in App options
 
 const DEFAULT_CLUSTER = "api-ceres.pusherplatform.io";
 
@@ -27,6 +33,9 @@ export default class App {
     private logger: Logger;
 
     constructor(options: AppOptions) {
+        if (!options.serviceId) {
+          throw new Error('Expected `serviceId` property in App options')
+        }
         this.serviceId = options.serviceId;
         this.tokenProvider = options.tokenProvider;
         this.client = options.client || new BaseClient({

--- a/test/unit/app.test.js
+++ b/test/unit/app.test.js
@@ -1,8 +1,15 @@
 const PusherPlatform = require('../../target/pusher-platform.js').default;
 
 describe('App', () => {
-    
+
     test('empty', () => {
         //No tests yet :(
     }) ;
+
+    it('Throws an error if `serviceId` is missing', () => {
+
+      expect(
+        () => new PusherPlatform.App({})
+      ).toThrow(new Error('Expected `serviceId` property in App options'));
+    })
 });


### PR DESCRIPTION
### What?
Adds some error handling for cases where `serviceId` is missing in the app options (plus tests for it)
...

#### Why?
After the recent api change, the old `appId` was causing silent errors which were reaching the server
...

#### How?
Explicitly checks in the App constructor if `serviceId` is present - throws an error if it isn't 
...

----

CC @pusher/sigsdk
