### PR TITLE
Enable all strict type checking options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,10 @@
     "sourceMap": true,
     "module": "commonjs",
     "lib": ["ES6", "dom"],
-    "declaration": true  
-    },
-    "exclude": [
-      "node_modules"
-    ]
+    "strict": true,
+    "declaration": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This PR is a work in progress. It currently adds the `--strict` option to tsconfig.
Run `yarn build` to see all the juicy new warnings!

See more here: https://www.typescriptlang.org/docs/handbook/compiler-options.html