### PR TITLE
Logger improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Like a subscription, but allows you to specify a `lastEventId` that will return 
 
 This is almost identical to Subscribe with the `lastEventId` and `retryStrategy`. By default it will use `ExponentialBackoffRetryStrategy`.
 
-### BaseClient
+### BaseClient
 
 This makes all the requests and executes them. They are [standard XHR objects](https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest). 
 It also creates XHRs that are used to create instances of `Subscription` and `ResumableSubscription`
@@ -134,10 +134,6 @@ export interface ResumableSubscribeOptions {
 
 Works the same as Subscription with the optional `retryStrategy` and `lastEventId`.
 
-### TokenProvider
-
-This will probably change.
-
 ### RetryStrategy
 
 __Note: currently this is not exported in the top-level.__
@@ -160,6 +156,8 @@ Configuration:
 ### Logger
 
 It logs things. 
+Interface:
+
 ```typescript
 export interface Logger {
     verbose(message: string, error?: Error);
@@ -170,7 +168,23 @@ export interface Logger {
 }
 ```
 
-Default implementation logs to console. You initiate it with a treshold for verbosity to filter log messages.
+You can pass it to the `App` object at startup. The default implementation is the `ConsoleLogger`. You initiate it with a threshold for the log level (defaults to `LogLevel.DEBUG`). It will log everything at or above this log level.
+
+The default log levels are:
+
+```typescript
+export enum LogLevel {
+     VERBOSE = 1,
+     DEBUG = 2,
+     INFO = 3,
+     WARNING = 4,
+     ERROR = 5
+}
+```
+
+### TokenProvider
+
+__DEPRECATED__ This will probably change.
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pusher-platform-js",
   "description": "Pusher Platform client library for web browsers",
   "main": "target/pusher-platform.js",
-  "version": "0.4.0",
+  "version": "0.5.0 ",
   "types": "target/index.d.ts",
   "author": "Pusher",
   "license": "MIT",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,9 @@
 import { TokenProvider } from './token-provider';
 import { BaseClient } from './base-client';
 import { RequestOptions } from './base-client';
-import { Subscription, SubscribeOptions } from './subscription';
-import { ResumableSubscription, ResumableSubscribeOptions } from './resumable-subscription'; 
-import { DefaultLogger, Logger } from './logger';
+import { ConsoleLogger, Logger } from './logger';
+import { ResumableSubscribeOptions, ResumableSubscription } from './resumable-subscription';
+import { SubscribeOptions, Subscription } from './subscription';
 
 const DEFAULT_CLUSTER = "api-ceres.pusherplatform.io";
 
@@ -34,11 +34,12 @@ export default class App {
                 sanitizeCluster(options.cluster) : DEFAULT_CLUSTER,
             encrypted: options.encrypted
         });
-        if(options.logger){
+
+        if(options.logger !== undefined){
             this.logger = options.logger;
         }
         else{
-            this.logger = new DefaultLogger();
+            this.logger = new ConsoleLogger();
         }
     }
 
@@ -72,11 +73,11 @@ export default class App {
         } else {
             subscription.open(null);
         }
-
         return subscription;
     }
 
     resumableSubscribe(options: ResumableSubscribeOptions): ResumableSubscription {
+        if(!options.logger) options.logger = this.logger;
         options.logger = this.logger;
         options.path = this.absPath(options.path);
         const tokenProvider = options.tokenProvider || this.tokenProvider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,24 @@
 import App from './app';
 import { BaseClient } from './base-client';
+import { ConsoleLogger, EmptyLogger, Logger } from './logger';
 import { ResumableSubscription } from './resumable-subscription';
+import { RetryStrategy, ExponentialBackoffRetryStrategy } from './retry-strategy';
 import { Subscription } from './subscription';
 
 export {
   App,
   BaseClient,
-  ResumableSubscription,
-  Subscription,
+  ResumableSubscription, Subscription,
+
+  RetryStrategy, ExponentialBackoffRetryStrategy,
+  Logger, ConsoleLogger, EmptyLogger, 
 };
 
 export default {
   App,
   BaseClient,
-  ResumableSubscription,
-  Subscription,
+  ResumableSubscription, Subscription,
+
+  ExponentialBackoffRetryStrategy,
+  ConsoleLogger, EmptyLogger
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,41 +15,57 @@ export interface Logger {
     error(message: string, error?: Error);
 }
 
-export class DefaultLogger implements Logger {
-    private treshold: LogLevel;
+/**
+ * Default implementation of the Logger. Wraps standards console calls.
+ * Logs only calls that are at or above the threshold (verbose/debug/info/warn/error)
+ * If error is passed, it will append the message to the error object. 
+ */
+export class ConsoleLogger implements Logger {
+    private threshold: LogLevel;
 
-    constructor(treshold: LogLevel = 2){
-        this.treshold = treshold;
+    constructor(threshold: LogLevel = 2){
+        this.threshold = threshold;
     }
 
-    private log(level: LogLevel, message: string, error?: Error): void {
-        if(level >= this.treshold){
-            console.log(message);
+    private log(
+        logFunction: (msg) => void, 
+        level: LogLevel, 
+        message: string, 
+        error?: Error): void {
 
-            if(error) {
-                console.log(error);
+            if(level >= this.threshold){
+                let loggerSignature = `Logger.${LogLevel[level]}`;
+
+                if(error){
+                    console.group();
+                    logFunction(`${loggerSignature}: ${message}`);
+                    logFunction(error);
+                    console.groupEnd();
+                }
+                else{
+                    logFunction(`${loggerSignature}: ${message}`);
+                }
             }
-        }
     }
 
     verbose(message: string, error?: Error){
-        this.log(LogLevel.VERBOSE, message, error);
+        this.log(console.log, LogLevel.VERBOSE, message, error);
     }
 
     debug(message: string, error?: Error){
-        this.log(LogLevel.DEBUG, message, error);
+        this.log(console.log, LogLevel.DEBUG, message, error);
     }
 
     info(message: string, error?: Error){
-        this.log(LogLevel.INFO, message, error);
+        this.log(console.info, LogLevel.INFO, message, error);
     }
 
     warn(message: string, error?: Error){
-        this.log(LogLevel.WARNING, message, error);
+        this.log(console.warn, LogLevel.WARNING, message, error);
     }
 
     error(message: string, error?: Error){
-        this.log(LogLevel.ERROR, message, error);
+        this.log(console.error, LogLevel.ERROR, message, error);
     }
 }
 

--- a/src/resumable-subscription.ts
+++ b/src/resumable-subscription.ts
@@ -44,7 +44,7 @@ export class ResumableSubscription {
     private assertState: Function;
     private subscription: Subscription;
     private lastEventIdReceived: string;
-    private retryStrategy: RetryStrategy = new ExponentialBackoffRetryStrategy({});
+    private retryStrategy: RetryStrategy;
     private logger?: Logger;
 
     constructor(
@@ -54,6 +54,15 @@ export class ResumableSubscription {
         this.assertState = assertState.bind(this, ResumableSubscriptionState);
         this.lastEventIdReceived = options.lastEventId;
         this.logger = options.logger;
+        
+        if(options.retryStrategy !== undefined){
+             this.retryStrategy = options.retryStrategy;
+        }
+        else{
+            this.retryStrategy = new ExponentialBackoffRetryStrategy({
+                logger: this.logger
+            })
+        }
     }
 
     tryNow(): void {
@@ -107,7 +116,7 @@ export class ResumableSubscription {
         this.tryNow();
     }
 
-    unsubscribe() {
-        this.subscription.unsubscribe(); // We'll get onEnd and bubble this up
+    unsubscribe(error?: Error) {
+        this.subscription.unsubscribe(error); // We'll get onEnd and bubble this up
     }
 }

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -1,5 +1,5 @@
 import { ErrorResponse, NetworkError } from './base-client';
-import { DefaultLogger, EmptyLogger, Logger } from './logger';
+import { ConsoleLogger, EmptyLogger, Logger } from './logger';
 export interface RetryStrategy {
     attemptRetry(error: Error): Promise<Error>;
 }
@@ -35,19 +35,19 @@ export class ExponentialBackoffRetryStrategy implements RetryStrategy {
         if(options.initialBackoffMilis) this.currentBackoffMilis = options.initialBackoffMilis;
         if(options.maxBackoffMilis) this.maxBackoffMilis = options.maxBackoffMilis;
 
-        if(options.logger) {
+        if(options.logger !== undefined) {
             this.logger = options.logger;
         } else{ 
-            this.logger = new DefaultLogger();
+            this.logger = new EmptyLogger();
         }
     }
 
     private shouldRetry(error: Error): RetryStrategyResult {
 
-        this.logger.debug(`${this.constructor.name}:  Error received`, error);
+        this.logger.verbose(`${this.constructor.name}:  Error received`, error);
         
         if(this.retryCount >= this.limit && this.limit > 0 ){
-            this.logger.debug(`${this.constructor.name}:  Retry count is over the maximum limit: ${this.limit}`);
+            this.logger.verbose(`${this.constructor.name}:  Retry count is over the maximum limit: ${this.limit}`);
             return new DoNotRetry(error);
         }
 
@@ -62,13 +62,13 @@ export class ExponentialBackoffRetryStrategy implements RetryStrategy {
                 this.currentBackoffMilis = this.calulateMilisToRetry();
                 this.retryCount += 1;
             
-                this.logger.debug(`${this.constructor.name}: Will attempt to retry in: ${this.currentBackoffMilis}`);
+                this.logger.verbose(`${this.constructor.name}: Will attempt to retry in: ${this.currentBackoffMilis}`);
                 return new Retry(this.currentBackoffMilis)
             }
         }
 
         else{
-            this.logger.debug(`${this.constructor.name}: Error is not retryable`, error);
+            this.logger.verbose(`${this.constructor.name}: Error is not retryable`, error);
             return new DoNotRetry(error);
         }
     }


### PR DESCRIPTION
### What?

Greatly log levels. 
If error is passed to the logger it will log the message and error in a separate group.
RetryStrategy now logs to the info level by default. This will avoid stuff like this: https://github.com/pusher/pusher-platform-js/issues/35

Also:  
More high level exports, including `Logger` and the `RetryStrategy`, as well as their implementations.
Renamed `DefaultLogger` to `ConsoleLogger`

----

CC @pusher/sigsdk
