### PR TITLE
Add support for retry callback

### DIFF
--- a/src/resumable-subscription.ts
+++ b/src/resumable-subscription.ts
@@ -86,7 +86,7 @@ export class ResumableSubscription {
                 this.state = ResumableSubscriptionState.OPENING
                 this.retryStrategy.attemptRetry(error)
                 .then(() => {
-                  if (this.options.onRetry !== null) {
+                  if (this.options.onRetry !== undefined) {
                     this.options.onRetry();
                   } else {
                     this.tryNow();


### PR DESCRIPTION
### What?
Add a callback to override resumable subscription retry behaviour
...

#### Why?
Clients of pusher platform JS may want (I have a use case) to do something custom when reconnecting. E.g. display an error message / log something etc.
...

#### How?
Added a new field to resumable subscription options which, if present, overrides the default retry behaviour
...

----

CC @pusher/sigsdk
