### PR TITLE
Fix small errors preventing retry-after behaviour

### DIFF
--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -56,6 +56,7 @@ export class ErrorResponse extends Error{
 
     constructor(statusCode: number, headers: Headers, info: any) {
         super(`ErroResponse: ${statusCode}: ${info} \n Headers: ${JSON.stringify(headers)}`);
+        Object.setPrototypeOf(this, ErrorResponse.prototype);
         this.statusCode = statusCode;
         this.headers = headers;
         this.info = info;

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -103,7 +103,7 @@ export class ExponentialBackoffRetryStrategy implements RetryStrategy {
 
          else if(error instanceof ErrorResponse) {
              //Only retry after is allowed
-             if(error.headers["retry-after"]) {
+             if(error.headers["Retry-After"]) {
                  retryable.isRetryable = true;
                  retryable.backoffMillis = parseInt(error.headers["retry-after"]) * 1000;
              }


### PR DESCRIPTION
 - Add hack to make ErrorResponse instance of ErrorResponse
 - Use proper capitalization of Retry-After header

### What?
A couple of small bug fixes that enable proper retry-after behavior
...

#### Why?
I need this behavior for TextSync :smile: 
...

#### How?
1 - Use the same technique used to fix NetworkError to make instanceOf ErrorResponse work
2 - Correct the capitalization of the "Retry-After" header
...

----

CC @pusher/sigsdk
