### PR TITLE
instance -> instanceId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
+## [v0.7.0] 2017-07-19
+
+### Changes
+
+- Renamed the `instance` to `instanceID` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
+- Won the Internet for the most confusing changelog entries.
+
 ## [v0.6.1] 2017-07-10
 
 ### Fixes
@@ -11,7 +18,7 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ## [v0.6.0] 2017-07-05
 
-## Changes
+### Changes
 
 - Changed the artifact name to `pusher-platform`
 - Renamed `App` to `Instance`, `appId` to `instanceId`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 ### Changes
 
-- Renamed the `instance` to `instanceID` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
+- Renamed the `instance` to `instanceId` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`. 
 - Won the Internet for the most confusing changelog entries.
 
 ## [v0.6.1] 2017-07-10

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ let instance = new Instance(...);
 ### Instance
 
 This is the main entry point - represents a single instance of a service running on the Elements infrastructure.
-Initialise with an `InstanceOptions` object that MUST contain at least the `instanceID`, `serviceName`, and `serviceVersion`.
+Initialise with an `InstanceOptions` object that MUST contain at least the `instanceId`, `serviceName`, and `serviceVersion`.
 
 InstanceOptions: 
 ```typescript
     serviceName: string; //Mandatory
-    instanceID: string; // Mandatory
+    instanceId: string; // Mandatory
     serviceVersion: string //Mandatory
 
-    host?: string; // Use in debugging, overrides the cluster setting that is the part of `instanceID` 
+    host?: string; // Use in debugging, overrides the cluster setting that is the part of `instanceId` 
     encrypted?: boolean; // Defaults to true
 
     client?: BaseClient; // You can provide custom implementation - this will probably be deprecated in the future

--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ let instance = new Instance(...);
 ### Instance
 
 This is the main entry point - represents a single instance of a service running on the Elements infrastructure.
-Initialise with an `InstanceOptions` object that MUST contain at least the `instance`, `serviceName`, and `serviceVersion`.
+Initialise with an `InstanceOptions` object that MUST contain at least the `instanceID`, `serviceName`, and `serviceVersion`.
 
 InstanceOptions: 
 ```typescript
     serviceName: string; //Mandatory
-    instance: string; // Mandatory
+    instanceID: string; // Mandatory
     serviceVersion: string //Mandatory
 
-    host?: string; // Defaults to "api-ceres.pusherplatform.io"
-    encrypted?: boolean;
+    host?: string; // Use in debugging, overrides the cluster setting that is the part of `instanceID` 
+    encrypted?: boolean; // Defaults to true
 
     client?: BaseClient; // You can provide custom implementation - this will probably be deprecated in the future
     tokenProvider?: TokenProvider; // You can provide custom implementation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pusher-platform",
   "description": "Pusher Platform client library for web browsers",
   "main": "target/pusher-platform.js",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "types": "declarations/index.d.ts",
   "author": "Pusher",
   "license": "MIT",

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -9,7 +9,7 @@ const HOST_BASE = "pusherplatform.io";
 
 export interface InstanceOptions {
 
-    instanceID: string;
+    instanceId: string;
     serviceName: string;
     serviceVersion: string;
     host?: string; //Allows to inject the hostname by default.
@@ -38,12 +38,12 @@ export default class Instance {
     private logger: Logger;
 
     constructor(options: InstanceOptions) {
-        if (!options.instanceID) throw new Error('Expected `instanceID` property in Instance options!');
-        if (options.instanceID.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
+        if (!options.instanceId) throw new Error('Expected `instanceId` property in Instance options!');
+        if (options.instanceId.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
         if(!options.serviceName) throw new Error('Expected `serviceName` property in Instance options!');
         if(!options.serviceVersion) throw new Error('Expected `serviceVersion` property in Instance otpions!');
         
-        let splitInstance = options.instanceID.split(":");
+        let splitInstance = options.instanceId.split(":");
         this.platformVersion = splitInstance[0];
         this.cluster = splitInstance[1];
         this.id = splitInstance[2];

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -9,7 +9,7 @@ const HOST_BASE = "pusherplatform.io";
 
 export interface InstanceOptions {
 
-    instance: string;
+    instanceID: string;
     serviceName: string;
     serviceVersion: string;
     host?: string; //Allows to inject the hostname by default.
@@ -28,7 +28,7 @@ export default class Instance {
     private client: BaseClient;
     private host: string;
 
-    private instanceId: string;
+    private id: string;
     private cluster: string;
     private platformVersion: string;
     private serviceVersion: string;
@@ -38,15 +38,15 @@ export default class Instance {
     private logger: Logger;
 
     constructor(options: InstanceOptions) {
-        if (!options.instance) throw new Error('Expected `instance` property in Instance options!');
-        if (options.instance.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
+        if (!options.instanceID) throw new Error('Expected `instanceID` property in Instance options!');
+        if (options.instanceID.split(":").length !== 3) throw new Error('The instance property is in the wrong format!');
         if(!options.serviceName) throw new Error('Expected `serviceName` property in Instance options!');
         if(!options.serviceVersion) throw new Error('Expected `serviceVersion` property in Instance otpions!');
         
-        let splitInstance = options.instance.split(":");
+        let splitInstance = options.instanceID.split(":");
         this.platformVersion = splitInstance[0];
         this.cluster = splitInstance[1];
-        this.instanceId = splitInstance[2];
+        this.id = splitInstance[2];
 
         this.serviceName = options.serviceName;
         this.serviceVersion = options.serviceVersion;
@@ -119,6 +119,6 @@ export default class Instance {
     }
 
     private absPath(relativePath: string): string {
-        return `/services/${this.serviceName}/${this.serviceVersion}/${this.instanceId}/${relativePath}`.replace(/\/+/g, "/").replace(/\/+$/, "");
+        return `/services/${this.serviceName}/${this.serviceVersion}/${this.id}/${relativePath}`.replace(/\/+/g, "/").replace(/\/+$/, "");
     }
 }

--- a/test/integration/request_failed.test.js
+++ b/test/integration/request_failed.test.js
@@ -7,7 +7,7 @@ describe('Instance requests - failing', () => {
 
     beforeAll(() => {
         instance = new PusherPlatform.Instance({
-            instance: "v1:api-ceres:1",
+            instanceId: "v1:api-ceres:1",
             serviceName: "platform_lib_tester",
             serviceVersion: "v1",
             host: "localhost:10443"

--- a/test/integration/request_successful.test.js
+++ b/test/integration/request_successful.test.js
@@ -6,7 +6,7 @@ describe('Instance Requests - Successful', () => {
 
     beforeAll(() => {
         instance = new PusherPlatform.Instance({
-            instance: "v1:api-ceres:1",
+            instanceId: "v1:api-ceres:1",
             serviceName: "platform_lib_tester",
             serviceVersion: "v1",
             host: "localhost:10443"

--- a/test/integration/subscribe-failed.test.js
+++ b/test/integration/subscribe-failed.test.js
@@ -7,7 +7,7 @@ describe('Instance Subscribe errors nicely', () => {
 
     beforeAll(() => {
         instance = new PusherPlatform.Instance({
-            instance: "v1:api-ceres:1",
+            instanceId: "v1:api-ceres:1",
             serviceName: "platform_lib_tester",
             serviceVersion: "v1",
             host: "localhost:10443"

--- a/test/integration/subscribe.test.js
+++ b/test/integration/subscribe.test.js
@@ -8,7 +8,7 @@ describe('Instance Subscribe', () => {
     beforeEach(() => {
 
         instance = new PusherPlatform.Instance({
-            instance: "v1:api-ceres:1",
+            instanceId: "v1:api-ceres:1",
             serviceName: "platform_lib_tester",
             serviceVersion: "v1",
             host: "localhost:10443"


### PR DESCRIPTION
### What?

Renamed the instance param to instanceId when instantiating the Instance. 
The `instance` field in the Instance is now called just `id`.

#### Why?

It should make things simpler, also on the service level.

#### How?

Using search and replace

----

CC @pusher/sigsdk
