### PR TITLE
Request with token bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
+## [v0.9.2] 2017-10-06
+
+### Fixes
+
+- Making authorized requests
+- Making authorized subscriptions
+
+
+
 ## [v0.9.0] 2017-09-14
 
 Refactored a lot of stuff internally, some API changes. This is a big release.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pusher-platform",
   "description": "Pusher Platform client library for web browsers",
   "main": "target/pusher-platform.js",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "types": "declarations/index.d.ts",
   "author": "Pusher",
   "license": "MIT",

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -41,18 +41,19 @@ export class BaseClient {
         }
     }
 
-    //TODO: add retrying
     public request(options: RequestOptions, tokenProvider?: TokenProvider, tokenParams?: any): PCancelable {
         if(tokenProvider){
-            return tokenProvider.fetchToken(tokenParams).then( token =>                  
+            return tokenProvider.fetchToken(tokenParams).then( token =>                
                 { 
-                    options.headers['Authorization'] = `Bearer: ${token}`
+                    options.headers['Authorization'] = `Bearer ${token}`
                     return executeNetworkRequest(
                         () => this.createXHR(this.baseURL, options),
                         options
                     )
                 }
-            );
+            ).catch( error => {
+                console.log(error);
+            })
         }
         else {
             return executeNetworkRequest(

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -65,9 +65,12 @@ export default class Instance {
         });
     }
 
-    request(options: RequestOptions): PCancelable{
+    request(options: RequestOptions, tokenProvider?: TokenProvider, tokenParams?: any): PCancelable{
         options.path = this.absPath(options.path);
-        return this.client.request(options);
+        if(options.headers == null || options.headers == undefined){
+            options.headers = {}
+        }
+        return this.client.request(options, tokenProvider, tokenParams);
     }
 
     subscribeNonResuming(options: SubscribeOptions): Subscription { 

--- a/test/manual/manual_test.js
+++ b/test/manual/manual_test.js
@@ -49,9 +49,6 @@ class TokenProvider {
                 })
                 xhr.open("POST", this.authEndpoint);
                 xhr.timeout = 3000;
-                xhr.onreadystatechange = () => {
-                    console.log(xhr.readyState);
-                }
                 xhr.onload = () => {
                   if (xhr.status === 200) {
                       let token = JSON.parse(xhr.responseText);
@@ -93,7 +90,7 @@ let subscribeOptions = {
 
 let requestOptions = {  
     method: "GET",
-    path: "feeds/my-feed/items",
+    path: "feeds/private-my-feed/items"
 }
 
 let postRequestOptions = {
@@ -104,18 +101,18 @@ let postRequestOptions = {
 
 
 
-// instance.request(postRequestOptions)
-//     .then( response => {
-//         console.log(response);
-//     }).catch( error => {
-//         console.log(error);
-//     });
-// function tryCancelRequest(){
-//     //TODO:
-// }
+instance.request(requestOptions, new TokenProvider())
+    .then( response => {
+        console.log(response);
+    }).catch( error => {
+        console.log(error);
+    });
+function tryCancelRequest(){
+    //TODO:
+}
 
 // let subscription = instance.subscribeResuming(subscribeOptions);
-let subscription = instance.subscribeNonResuming(subscribeOptions);
+// let subscription = instance.subscribeNonResuming(subscribeOptions);
 // let subscription = instance.subscribeNonResuming(subscribeOptions);
 
 function tryUnsubscribe(){


### PR DESCRIPTION
### What?

Authorized requests now work correctly.
Authorized requests blew up when headers were not provided as part of `RequestOptions`

----

CC @pusher/sigsdk
