### PR TITLE
Unopinionated, Raw network requests

### DIFF
--- a/dist/react-native/declarations/index.d.ts
+++ b/dist/react-native/declarations/index.d.ts
@@ -2,7 +2,7 @@ import { BaseClient, BaseClientOptions } from './base-client';
 import { default as Instance, ResumableSubscribeOptions, SubscribeOptions } from './instance';
 import { ConsoleLogger, EmptyLogger, Logger } from './logger';
 import { ElementsHeaders, ErrorResponse, NetworkError, responseToHeadersObject, XhrReadyState } from './network';
-import { executeNetworkRequest, RequestOptions } from './request';
+import { executeNetworkRequest, RawRequestOptions, RequestOptions, sendRawRequest } from './request';
 import { createResumingStrategy } from './resuming-subscription';
 import { createRetryStrategyOptionsOrDefault, DoNotRetry, Retry, RetryResolution, RetryStrategyOptions, RetryStrategyResult } from './retry-strategy';
 import { createRetryingStrategy } from './retrying-subscription';
@@ -10,7 +10,7 @@ import { Subscription, SubscriptionEvent, SubscriptionListeners } from './subscr
 import { TokenProvider } from './token-provider';
 import { createTokenProvidingStrategy } from './token-providing-subscription';
 import { createTransportStrategy } from './transports';
-export { BaseClient, BaseClientOptions, ConsoleLogger, createResumingStrategy, createRetryingStrategy, createRetryStrategyOptionsOrDefault, createTokenProvidingStrategy, createTransportStrategy, DoNotRetry, ElementsHeaders, EmptyLogger, ErrorResponse, executeNetworkRequest, Instance, Logger, NetworkError, RequestOptions, responseToHeadersObject, ResumableSubscribeOptions, RetryStrategyResult, Retry, RetryStrategyOptions, RetryResolution, SubscribeOptions, Subscription, SubscriptionEvent, SubscriptionListeners, TokenProvider, XhrReadyState };
+export { BaseClient, BaseClientOptions, ConsoleLogger, createResumingStrategy, createRetryingStrategy, createRetryStrategyOptionsOrDefault, createTokenProvidingStrategy, createTransportStrategy, DoNotRetry, ElementsHeaders, EmptyLogger, ErrorResponse, executeNetworkRequest, Instance, Logger, NetworkError, RawRequestOptions, RequestOptions, responseToHeadersObject, ResumableSubscribeOptions, RetryStrategyResult, Retry, RetryStrategyOptions, RetryResolution, sendRawRequest, SubscribeOptions, Subscription, SubscriptionEvent, SubscriptionListeners, TokenProvider, XhrReadyState };
 declare const _default: {
     BaseClient: typeof BaseClient;
     ConsoleLogger: typeof ConsoleLogger;

--- a/dist/react-native/declarations/request.d.ts
+++ b/dist/react-native/declarations/request.d.ts
@@ -11,4 +11,12 @@ export interface RequestOptions {
     logger?: Logger;
     tokenProvider?: TokenProvider;
 }
+export interface RawRequestOptions {
+    method: string;
+    url: string;
+    headers?: ElementsHeaders;
+    body?: any;
+    logger?: Logger;
+}
 export declare function executeNetworkRequest(createXhr: () => XMLHttpRequest, options: RequestOptions): Promise<any>;
+export declare function sendRawRequest(options: RawRequestOptions): Promise<any>;

--- a/dist/react-native/pusher-platform.js
+++ b/dist/react-native/pusher-platform.js
@@ -435,30 +435,49 @@ exports.BaseClient = BaseClient;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-
+/* WEBPACK VAR INJECTION */(function(global) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var network_1 = __webpack_require__(0);
 function executeNetworkRequest(createXhr, options) {
     return new Promise(function (resolve, reject) {
-        var xhr = createXhr();
-        xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4) {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr.response);
-                }
-                else if (xhr.status !== 0) {
-                    reject(network_1.ErrorResponse.fromXHR(xhr));
-                }
-                else {
-                    reject(new network_1.NetworkError('No Connection'));
-                }
-            }
-        };
+        var xhr = attachOnReadyStateChangeHandler(createXhr(), resolve, reject);
         xhr.send(JSON.stringify(options.body));
     });
 }
 exports.executeNetworkRequest = executeNetworkRequest;
+function sendRawRequest(options) {
+    return new Promise(function (resolve, reject) {
+        var xhr = attachOnReadyStateChangeHandler(new global.XMLHttpRequest(), resolve, reject);
+        xhr.open(options.method.toUpperCase(), options.url, true);
+        if (options.headers) {
+            for (var key in options.headers) {
+                if (options.headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, options.headers[key]);
+                }
+            }
+        }
+        xhr.send(options.body);
+    });
+}
+exports.sendRawRequest = sendRawRequest;
+function attachOnReadyStateChangeHandler(xhr, resolve, reject) {
+    xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve(xhr.response);
+            }
+            else if (xhr.status !== 0) {
+                reject(network_1.ErrorResponse.fromXHR(xhr));
+            }
+            else {
+                reject(new network_1.NetworkError('No Connection'));
+            }
+        }
+    };
+    return xhr;
+}
 
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
 /* 6 */
@@ -900,6 +919,7 @@ exports.responseToHeadersObject = network_1.responseToHeadersObject;
 exports.XhrReadyState = network_1.XhrReadyState;
 var request_1 = __webpack_require__(5);
 exports.executeNetworkRequest = request_1.executeNetworkRequest;
+exports.sendRawRequest = request_1.sendRawRequest;
 var resuming_subscription_1 = __webpack_require__(6);
 exports.createResumingStrategy = resuming_subscription_1.createResumingStrategy;
 var retry_strategy_1 = __webpack_require__(3);

--- a/dist/web/declarations/index.d.ts
+++ b/dist/web/declarations/index.d.ts
@@ -2,7 +2,7 @@ import { BaseClient, BaseClientOptions } from './base-client';
 import { default as Instance, ResumableSubscribeOptions, SubscribeOptions } from './instance';
 import { ConsoleLogger, EmptyLogger, Logger } from './logger';
 import { ElementsHeaders, ErrorResponse, NetworkError, responseToHeadersObject, XhrReadyState } from './network';
-import { executeNetworkRequest, RequestOptions } from './request';
+import { executeNetworkRequest, RawRequestOptions, RequestOptions, sendRawRequest } from './request';
 import { createResumingStrategy } from './resuming-subscription';
 import { createRetryStrategyOptionsOrDefault, DoNotRetry, Retry, RetryResolution, RetryStrategyOptions, RetryStrategyResult } from './retry-strategy';
 import { createRetryingStrategy } from './retrying-subscription';
@@ -10,7 +10,7 @@ import { Subscription, SubscriptionEvent, SubscriptionListeners } from './subscr
 import { TokenProvider } from './token-provider';
 import { createTokenProvidingStrategy } from './token-providing-subscription';
 import { createTransportStrategy } from './transports';
-export { BaseClient, BaseClientOptions, ConsoleLogger, createResumingStrategy, createRetryingStrategy, createRetryStrategyOptionsOrDefault, createTokenProvidingStrategy, createTransportStrategy, DoNotRetry, ElementsHeaders, EmptyLogger, ErrorResponse, executeNetworkRequest, Instance, Logger, NetworkError, RequestOptions, responseToHeadersObject, ResumableSubscribeOptions, RetryStrategyResult, Retry, RetryStrategyOptions, RetryResolution, SubscribeOptions, Subscription, SubscriptionEvent, SubscriptionListeners, TokenProvider, XhrReadyState };
+export { BaseClient, BaseClientOptions, ConsoleLogger, createResumingStrategy, createRetryingStrategy, createRetryStrategyOptionsOrDefault, createTokenProvidingStrategy, createTransportStrategy, DoNotRetry, ElementsHeaders, EmptyLogger, ErrorResponse, executeNetworkRequest, Instance, Logger, NetworkError, RawRequestOptions, RequestOptions, responseToHeadersObject, ResumableSubscribeOptions, RetryStrategyResult, Retry, RetryStrategyOptions, RetryResolution, sendRawRequest, SubscribeOptions, Subscription, SubscriptionEvent, SubscriptionListeners, TokenProvider, XhrReadyState };
 declare const _default: {
     BaseClient: typeof BaseClient;
     ConsoleLogger: typeof ConsoleLogger;

--- a/dist/web/declarations/request.d.ts
+++ b/dist/web/declarations/request.d.ts
@@ -11,4 +11,12 @@ export interface RequestOptions {
     logger?: Logger;
     tokenProvider?: TokenProvider;
 }
+export interface RawRequestOptions {
+    method: string;
+    url: string;
+    headers?: ElementsHeaders;
+    body?: any;
+    logger?: Logger;
+}
 export declare function executeNetworkRequest(createXhr: () => XMLHttpRequest, options: RequestOptions): Promise<any>;
+export declare function sendRawRequest(options: RawRequestOptions): Promise<any>;

--- a/dist/web/pusher-platform.js
+++ b/dist/web/pusher-platform.js
@@ -421,24 +421,42 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var network_1 = __webpack_require__(0);
 function executeNetworkRequest(createXhr, options) {
     return new Promise(function (resolve, reject) {
-        var xhr = createXhr();
-        xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4) {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr.response);
-                }
-                else if (xhr.status !== 0) {
-                    reject(network_1.ErrorResponse.fromXHR(xhr));
-                }
-                else {
-                    reject(new network_1.NetworkError('No Connection'));
-                }
-            }
-        };
+        var xhr = attachOnReadyStateChangeHandler(createXhr(), resolve, reject);
         xhr.send(JSON.stringify(options.body));
     });
 }
 exports.executeNetworkRequest = executeNetworkRequest;
+function sendRawRequest(options) {
+    return new Promise(function (resolve, reject) {
+        var xhr = attachOnReadyStateChangeHandler(new window.XMLHttpRequest(), resolve, reject);
+        xhr.open(options.method.toUpperCase(), options.url, true);
+        if (options.headers) {
+            for (var key in options.headers) {
+                if (options.headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, options.headers[key]);
+                }
+            }
+        }
+        xhr.send(options.body);
+    });
+}
+exports.sendRawRequest = sendRawRequest;
+function attachOnReadyStateChangeHandler(xhr, resolve, reject) {
+    xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve(xhr.response);
+            }
+            else if (xhr.status !== 0) {
+                reject(network_1.ErrorResponse.fromXHR(xhr));
+            }
+            else {
+                reject(new network_1.NetworkError('No Connection'));
+            }
+        }
+    };
+    return xhr;
+}
 
 
 /***/ }),
@@ -879,6 +897,7 @@ exports.responseToHeadersObject = network_1.responseToHeadersObject;
 exports.XhrReadyState = network_1.XhrReadyState;
 var request_1 = __webpack_require__(4);
 exports.executeNetworkRequest = request_1.executeNetworkRequest;
+exports.sendRawRequest = request_1.sendRawRequest;
 var resuming_subscription_1 = __webpack_require__(5);
 exports.createResumingStrategy = resuming_subscription_1.createResumingStrategy;
 var retry_strategy_1 = __webpack_require__(2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,12 @@ import {
   responseToHeadersObject,
   XhrReadyState,
 } from './network';
-import { executeNetworkRequest, RequestOptions } from './request';
+import {
+  executeNetworkRequest,
+  RawRequestOptions,
+  RequestOptions,
+  sendRawRequest,
+} from './request';
 import { createResumingStrategy } from './resuming-subscription';
 import {
   createRetryStrategyOptionsOrDefault,
@@ -50,6 +55,7 @@ export {
   Instance,
   Logger,
   NetworkError,
+  RawRequestOptions,
   RequestOptions,
   responseToHeadersObject,
   ResumableSubscribeOptions,
@@ -57,6 +63,7 @@ export {
   Retry,
   RetryStrategyOptions,
   RetryResolution,
+  sendRawRequest,
   SubscribeOptions,
   Subscription,
   SubscriptionEvent,

--- a/src/request.ts
+++ b/src/request.ts
@@ -14,25 +14,63 @@ export interface RequestOptions {
   tokenProvider?: TokenProvider;
 }
 
+export interface RawRequestOptions {
+  method: string;
+  url: string;
+  headers?: ElementsHeaders;
+  body?: any;
+  logger?: Logger;
+}
+
 // TODO: Could we make this generic and remove the `any`s?
 export function executeNetworkRequest(
   createXhr: () => XMLHttpRequest,
   options: RequestOptions,
 ): Promise<any> {
   return new Promise<any>((resolve, reject) => {
-    const xhr = createXhr();
+    const xhr = attachOnReadyStateChangeHandler(createXhr(), resolve, reject);
 
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState === 4) {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(xhr.response);
-        } else if (xhr.status !== 0) {
-          reject(ErrorResponse.fromXHR(xhr));
-        } else {
-          reject(new NetworkError('No Connection'));
-        }
-      }
-    };
     xhr.send(JSON.stringify(options.body));
   });
+}
+
+export function sendRawRequest(options: RawRequestOptions): Promise<any> {
+  return new Promise<any>((resolve, reject) => {
+    const xhr = attachOnReadyStateChangeHandler(
+      new global.XMLHttpRequest(),
+      resolve,
+      reject,
+    );
+
+    xhr.open(options.method.toUpperCase(), options.url, true);
+
+    if (options.headers) {
+      for (const key in options.headers) {
+        if (options.headers.hasOwnProperty(key)) {
+          xhr.setRequestHeader(key, options.headers[key]);
+        }
+      }
+    }
+
+    xhr.send(options.body);
+  });
+}
+
+function attachOnReadyStateChangeHandler(
+  xhr: XMLHttpRequest,
+  resolve: any,
+  reject: any,
+): XMLHttpRequest {
+  xhr.onreadystatechange = () => {
+    if (xhr.readyState === 4) {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(xhr.response);
+      } else if (xhr.status !== 0) {
+        reject(ErrorResponse.fromXHR(xhr));
+      } else {
+        reject(new NetworkError('No Connection'));
+      }
+    }
+  };
+  return xhr;
 }


### PR DESCRIPTION
Ignore everything in `dist/` as that's just build artefacts.

### What?

Add `executeRawNetworkRequest` and `RawRequestOptions` to let service SDK builders make raw network requests. 

### Why?

Make raw network requests without having to worry about networking environment in service SDKs.

### How?

Expose a new function and a new interface.

----

CC @pusher/sigsdk