### PR TITLE
Dont jsonify by default

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -2,15 +2,24 @@ import { Logger } from './logger';
 import { ElementsHeaders, ErrorResponse, NetworkError } from './network';
 import { TokenProvider } from './token-provider';
 
-export interface RequestOptions {
+export interface BasicRequestOptions {
   method: string;
   path: string;
   jwt?: string;
   headers?: ElementsHeaders;
-  body?: any;
   logger?: Logger;
   tokenProvider?: TokenProvider;
 }
+
+export interface SimpleRequestOptions extends BasicRequestOptions {
+  body?: any;
+}
+
+export interface JSONRequestOptions extends BasicRequestOptions {
+  json?: any;
+}
+
+export type RequestOptions = SimpleRequestOptions | JSONRequestOptions;
 
 export interface RawRequestOptions {
   method: string;
@@ -27,9 +36,16 @@ export function executeNetworkRequest(
 ): Promise<any> {
   return new Promise<any>((resolve, reject) => {
     const xhr = attachOnReadyStateChangeHandler(createXhr(), resolve, reject);
-
-    xhr.send(JSON.stringify(options.body));
+    sendBody(xhr, options);
   });
+}
+
+function sendBody(xhr: XMLHttpRequest, options: any) {
+  if (options.json) {
+    xhr.send(JSON.stringify(options.json));
+  } else {
+    xhr.send(options.body);
+  }
 }
 
 export function sendRawRequest(options: RawRequestOptions): Promise<any> {

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -323,13 +323,11 @@ export default class HttpTransport implements SubscriptionTransport {
   }
 
   private createXHR(baseURL: string, options: RequestOptions): XMLHttpRequest {
-    const xhr = new global.XMLHttpRequest();
+    let xhr = new global.XMLHttpRequest();
     const path = options.path.replace(/^\/+/, '');
     const endpoint = `${baseURL}/${path}`;
     xhr.open(options.method.toUpperCase(), endpoint, true);
-    if (options.body) {
-      xhr.setRequestHeader('content-type', 'application/json');
-    }
+    xhr = this.setJSONHeaderIfAppropriate(xhr, options);
     if (options.jwt) {
       xhr.setRequestHeader('authorization', `Bearer ${options.jwt}`);
     }
@@ -340,6 +338,16 @@ export default class HttpTransport implements SubscriptionTransport {
           xhr.setRequestHeader(key, options.headers[key]);
         }
       }
+    }
+    return xhr;
+  }
+
+  private setJSONHeaderIfAppropriate(
+    xhr: XMLHttpRequest,
+    options: any,
+  ): XMLHttpRequest {
+    if (options.json) {
+      xhr.setRequestHeader('content-type', 'application/json');
     }
     return xhr;
   }

--- a/test/integration/request_successful.test.js
+++ b/test/integration/request_successful.test.js
@@ -36,12 +36,12 @@ describe('Instance Requests - Successful', () => {
       });
   });
 
-  it('makes a successful POST request with body', done => {
+  it('makes a successful POST request with JSON body', done => {
     instance
       .request({
         method: 'post',
         path: 'post_ok',
-        body: {
+        json: {
           test: '123',
         },
       })


### PR DESCRIPTION
### What?

Don't add JSON content type headers or JSON stringify everything that has a body in its request options by default.

Let requests be made with a `json` key, instead of a `body` key to preserve easy JSON sending.

### Why?

Chatkit wants to start supporting different content types while still being able to use the same request flow.

----

CC @pusher/sigsdk