### PR TITLE
Make HOST_BASE exported

### DIFF
--- a/src/host_base.ts
+++ b/src/host_base.ts
@@ -1,0 +1,1 @@
+export const HOST_BASE = 'pusherplatform.io';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { BaseClient, BaseClientOptions } from './base-client';
+import { HOST_BASE } from './host_base';
 import {
   default as Instance,
   ResumableSubscribeOptions,
@@ -52,6 +53,7 @@ export {
   EmptyLogger,
   ErrorResponse,
   executeNetworkRequest,
+  HOST_BASE,
   Instance,
   Logger,
   NetworkError,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,12 +1,11 @@
 import { BaseClient } from './base-client';
+import { HOST_BASE } from './host_base';
 import { ConsoleLogger, Logger } from './logger';
 import { ElementsHeaders } from './network';
 import { RequestOptions } from './request';
 import { RetryStrategyOptions } from './retry-strategy';
 import { Subscription, SubscriptionListeners } from './subscription';
 import { TokenProvider } from './token-provider';
-
-const HOST_BASE = 'pusherplatform.io';
 
 export interface InstanceOptions {
   locator: string;
@@ -46,22 +45,25 @@ export default class Instance {
     if (!options.locator) {
       throw new Error('Expected `locator` property in Instance options!');
     }
-    if (options.locator.split(':').length !== 3) {
+
+    const splitInstanceLocator = options.locator.split(':');
+    if (splitInstanceLocator.length !== 3) {
       throw new Error('The instance locator property is in the wrong format!');
     }
+
     if (!options.serviceName) {
       throw new Error('Expected `serviceName` property in Instance options!');
     }
+
     if (!options.serviceVersion) {
       throw new Error(
         'Expected `serviceVersion` property in Instance otpions!',
       );
     }
 
-    const splitLocator = options.locator.split(':');
-    this.platformVersion = splitLocator[0];
-    this.cluster = splitLocator[1];
-    this.id = splitLocator[2];
+    this.platformVersion = splitInstanceLocator[0];
+    this.cluster = splitInstanceLocator[1];
+    this.id = splitInstanceLocator[2];
 
     this.serviceName = options.serviceName;
     this.serviceVersion = options.serviceVersion;


### PR DESCRIPTION
### What?

Export the `HOST_BASE` value. Also moved it into its own file.

### Why?

So service SDKs can access it if needs be, e.g. with Chatkit https://github.com/pusher/chatkit-client-js/pull/12/files#diff-ed4e01df13a27a155e155300e01a7e6cR38

### How?



----

CC @pusher/sigsdk