### PR TITLE
Add support for web workers with worker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   },
   "scripts": {
     "build": "yarn build:all",
-    "build:all": "yarn clean && yarn build:web && yarn build:react-native",
+    "build:all": "yarn clean && yarn build:web && yarn build:react-native && yarn build:worker",
     "build:web": "webpack --config=webpack/config.web.js",
     "build:react-native": "webpack --config=webpack/config.react-native.js",
+    "build:worker": "webpack --config=webpack/config.worker.js",
     "clean": "rm -rf dist",
     "format": "yarn prettier --write",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",

--- a/webpack/config.react-native.js
+++ b/webpack/config.react-native.js
@@ -4,6 +4,9 @@ var path = require('path');
 var sharedConfig = require('./config.shared');
 
 module.exports = _.merge(sharedConfig, {
+  entry: {
+    'pusher-platform': './src/index.ts'
+  },
   output: {
     library: "PusherPlatform",
     libraryTarget:"commonjs2",

--- a/webpack/config.shared.js
+++ b/webpack/config.shared.js
@@ -1,9 +1,6 @@
 var webpack = require('webpack');
 
 module.exports = {
-  entry: {
-    'pusher-platform': './src/index.ts'
-  },
   resolve: {
     extensions: ['.ts', '.js'],
   },

--- a/webpack/config.worker.js
+++ b/webpack/config.worker.js
@@ -6,17 +6,16 @@ var sharedConfig = require('./config.shared');
 
 module.exports = _.merge(sharedConfig, {
   entry: {
-    'pusher-platform': './src/index.ts'
+    'pusher-platform.worker': './src/index.ts'
   },
   output: {
     library: "PusherPlatform",
-    path: path.join(__dirname, "../dist/web"),
-    filename: "pusher-platform.js",
-    libraryTarget: "umd"
+    path: path.join(__dirname, "../dist/worker"),
+    filename: "pusher-platform.worker.js"
   },
   plugins: [
     new webpack.DefinePlugin({
-      global: "window"
+      global: "self"
     }),
-  ],
+  ]
 });

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/worker/pusher-platform.worker');


### PR DESCRIPTION
### What?

Add support for web workers with worker build

### Why?

Support for web workers

### How?

Another new build, as we did with `react-native`.

Note that this won't work with ServiceWorkers because we still rely on XMLHttpRequest. 

----

CC @pusher/sigsdk