### PR TITLE
Friendlier error message for instance locator

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -48,7 +48,7 @@ export default class Instance {
 
     const splitInstanceLocator = options.locator.split(':');
     if (splitInstanceLocator.length !== 3) {
-      throw new Error('The instance locator property is in the wrong format!');
+      throw new Error('The instance locator supplied is invalid. Did you copy it correctly from the Pusher dashboard?');
     }
 
     if (!options.serviceName) {
@@ -57,7 +57,7 @@ export default class Instance {
 
     if (!options.serviceVersion) {
       throw new Error(
-        'Expected `serviceVersion` property in Instance otpions!',
+        'Expected `serviceVersion` property in Instance options!',
       );
     }
 


### PR DESCRIPTION


### What?
A more user-friendly error message when an invalid instance locator is supplied.


### Why?
We've run into this error a couple of times and the current error message is quite cryptic.  Users are pretty likely to run into this error occasionally, so a friendlier message that nudges someone in the right direction might be a good idea.


### How?
Rewording the message.  Also spotted a typo in a neighbouring error message :)


----

CC @pusher/sigsdk
