### PR TITLE
Reject when rejection is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
+## Unreleased
+
+### Changes
+
+- `RequestOptions` and `RawRequestOptions` no longer have `logger` as an optional property
+
+### Fixes
+
+- Rejected promises arising from failed network requests now propogate as you'd expect
+
 ## [v0.14.0] 2017-12-07
 
 ### Changes

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -50,20 +50,12 @@ export class BaseClient {
               ['Authorization']: `Bearer ${token}`,
             };
           }
-          return executeNetworkRequest(
-            () => this.httpTransport.request(options),
-            options,
-          );
+          return options;
         })
-        .catch(error => {
-          this.logger.error(error);
-        });
+        .then(optionsWithToken => this.makeRequest(optionsWithToken));
     }
 
-    return executeNetworkRequest(
-      () => this.httpTransport.request(options),
-      options,
-    );
+    return this.makeRequest(options);
   }
 
   subscribeResuming(
@@ -147,5 +139,15 @@ export class BaseClient {
       },
       headers,
     );
+  }
+
+  private makeRequest(options: RequestOptions): Promise<any> {
+    return executeNetworkRequest(
+      () => this.httpTransport.request(options),
+      options,
+    ).catch(error => {
+      this.logger.error(error);
+      throw error;
+    });
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import { Logger } from './logger';
+import { ConsoleLogger, Logger } from './logger';
 import { ElementsHeaders, ErrorResponse, NetworkError } from './network';
 import { TokenProvider } from './token-provider';
 
@@ -7,7 +7,6 @@ export interface BasicRequestOptions {
   path: string;
   jwt?: string;
   headers?: ElementsHeaders;
-  logger?: Logger;
   tokenProvider?: TokenProvider;
 }
 
@@ -26,7 +25,6 @@ export interface RawRequestOptions {
   url: string;
   headers?: ElementsHeaders;
   body?: any;
-  logger?: Logger;
 }
 
 // TODO: Could we make this generic and remove the `any`s?

--- a/test/integration/request_failed.test.js
+++ b/test/integration/request_failed.test.js
@@ -5,6 +5,7 @@ const {
 //these just test GET - everything else should just work.
 describe('Instance requests - failing', () => {
   let instance;
+  let instanceWithTokenProvider;
 
   beforeAll(() => {
     instance = new PusherPlatform.Instance({
@@ -13,80 +14,175 @@ describe('Instance requests - failing', () => {
       serviceVersion: 'v1',
       host: 'localhost:10443',
     });
+
+    class DummyTokenProvider {
+      fetchToken(tokenParams) {
+        return Promise.resolve('blahblaharandomtoken');
+      }
+
+      clearToken(token) {}
+    }
+
+    instanceWithTokenProvider = new PusherPlatform.Instance({
+      locator: 'v1:api-ceres:1',
+      serviceName: 'platform_sdk_tester',
+      serviceVersion: 'v1',
+      host: 'localhost:10443',
+      tokenProvider: new DummyTokenProvider(),
+    });
   });
 
-  it('fails on 400 error', done => {
-    instance
-      .request({
-        method: 'GET',
-        path: 'get_400',
-      })
-      .then(res => {
-        fail('Expecting error');
-      })
-      .catch(error => {
-        expect(error.statusCode).toBe(400);
-        done();
-      });
+  describe('with no token provider', () => {
+    it('fails on 400 error', done => {
+      instance
+        .request({
+          method: 'GET',
+          path: 'get_400',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(400);
+          done();
+        });
+    });
+
+    it('fails on 403 error', done => {
+      instance
+        .request({
+          method: 'GET',
+          path: 'get_403',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(403);
+          done();
+        });
+    });
+
+    it('fails on 404 error', done => {
+      instance
+        .request({
+          method: 'GET',
+          path: 'get_404',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(404);
+          done();
+        });
+    });
+
+    it('fails on 500 error', done => {
+      instance
+        .request({
+          method: 'GET',
+          path: 'get_500',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(500);
+          done();
+        });
+    });
+
+    it('fails on 503 error', done => {
+      instance
+        .request({
+          method: 'GET',
+          path: 'get_503',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(503);
+          done();
+        });
+    });
   });
 
-  it('fails on 403 error', done => {
-    instance
-      .request({
-        method: 'GET',
-        path: 'get_403',
-      })
-      .then(res => {
-        fail('Expecting error');
-      })
-      .catch(error => {
-        expect(error.statusCode).toBe(403);
-        done();
-      });
-  });
+  describe('with a token provider', () => {
+    it('fails on 400 error', done => {
+      instanceWithTokenProvider
+        .request({
+          method: 'GET',
+          path: 'get_400',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(400);
+          done();
+        });
+    });
 
-  it('fails on 404 error', done => {
-    instance
-      .request({
-        method: 'GET',
-        path: 'get_404',
-      })
-      .then(res => {
-        fail('Expecting error');
-      })
-      .catch(error => {
-        expect(error.statusCode).toBe(404);
-        done();
-      });
-  });
+    it('fails on 403 error', done => {
+      instanceWithTokenProvider
+        .request({
+          method: 'GET',
+          path: 'get_403',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(403);
+          done();
+        });
+    });
 
-  it('fails on 500 error', done => {
-    instance
-      .request({
-        method: 'GET',
-        path: 'get_500',
-      })
-      .then(res => {
-        fail('Expecting error');
-      })
-      .catch(error => {
-        expect(error.statusCode).toBe(500);
-        done();
-      });
-  });
+    it('fails on 404 error', done => {
+      instanceWithTokenProvider
+        .request({
+          method: 'GET',
+          path: 'get_404',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(404);
+          done();
+        });
+    });
 
-  it('fails on 503 error', done => {
-    instance
-      .request({
-        method: 'GET',
-        path: 'get_503',
-      })
-      .then(res => {
-        fail('Expecting error');
-      })
-      .catch(error => {
-        expect(error.statusCode).toBe(503);
-        done();
-      });
+    it('fails on 500 error', done => {
+      instanceWithTokenProvider
+        .request({
+          method: 'GET',
+          path: 'get_500',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(500);
+          done();
+        });
+    });
+
+    it('fails on 503 error', done => {
+      instanceWithTokenProvider
+        .request({
+          method: 'GET',
+          path: 'get_503',
+        })
+        .then(res => {
+          fail('Expecting error');
+        })
+        .catch(error => {
+          expect(error.statusCode).toBe(503);
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
### What?

Make requests that don't return a 200...300 status code reject the returned promise.

### Why?

Network requests that completed with a status code not in the range 200...300 were being caught for logging reasons, but that meant they were not being considered rejected by the time the caller's `Promise` was being fulfilled.

### How?

Remove the offending `catch` block and move logging elsewhere.

----

CC @pusher/sigsdk