### PR TITLE
Reconnect after 503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,38 @@
-# Change Log
+# Changelog
 
 This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
-## Unreleased
+---
 
-## [v0.15.5] 2018-11-19
+## [Unreleased](https://github.com/pusher/pusher-platform-js/compare/0.15.5...HEAD)
+
+### Fixes
+
+- Reconnections and subscription retries now occur as expected when the websocket transport receives a close message
+
+## [0.15.5](https://github.com/pusher/pusher-platform-js/compare/0.15.3...0.15.5) - 2018-11-19
 
 - Adopt package in to the pusher org as `@pusher/platform`
 
-## [v0.15.3] 2018-11-16
+## [0.15.3](https://github.com/pusher/pusher-platform-js/compare/0.15.2...0.15.3) - 2018-11-16
 
-- Work around Chrome taking 60 seconds to close a broken websocket by disposing of
-  the registered callbacks and proceeding immediately with a new one
+### Fixes
 
-## [v0.15.2] 2018-10-12
+- Work around Chrome taking 60 seconds to close a broken websocket by disposing of the registered callbacks and proceeding immediately with a new one
+
+## [0.15.2](https://github.com/pusher/pusher-platform-js/compare/0.15.1...0.15.2) - 2018-10-12
 
 ### Changes
 
 - Don't close websocket connection if received pong ID doesn't match last send ping ID
 
-## [v0.15.1] 2018-04-10
+## [0.15.1](https://github.com/pusher/pusher-platform-js/compare/0.15.0...0.15.1) - 2018-04-10
 
 ### Additions
 
 - `BaseClient` takes `sdkProduct` and `sdkVersion` options. Sends them as headers with every request (along with language and platform).
 
-## [v0.15.0] 2018-03-07
+## [0.15.0](https://github.com/pusher/pusher-platform-js/compare/0.14.0...0.15.0) - 2018-03-07
 
 ### Changes
 
@@ -35,29 +42,25 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 
 - Rejected promises arising from failed network requests, where a token provider was being used, now propogate as you'd expect
 
-
-## [v0.14.0] 2017-12-07
+## [0.14.0](https://github.com/pusher/pusher-platform-js/compare/0.13.2...0.14.0) - 2017-12-07
 
 ### Changes
 
 - Added support for web workers with a build for web workers
 
-
-## [v0.13.2] 2017-12-05
+## [0.13.2](https://github.com/pusher/pusher-platform-js/compare/0.13.1...0.13.2) - 2017-12-05
 
 ### Changes
 
 - `tokenProvider` property on `Instance` is now public
 
-
-## [v0.13.1] 2017-12-05
+## [0.13.1](https://github.com/pusher/pusher-platform-js/compare/0.13.0...0.13.1) - 2017-12-05
 
 ### Changes
 
 - `HOST_BASE` is now exported
 
-
-## [v0.13.0] 2017-11-28
+## [0.13.0](https://github.com/pusher/pusher-platform-js/compare/0.12.4...0.13.0) - 2017-11-28
 
 ### Changes
 
@@ -66,35 +69,35 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 - The default `ConsoleLogger` will now log out `error_uri`s and `error_description`s in a helpful way, if they're present as part of an `ErrorResponse` object passed to a logger call.
 
 
-## [v0.12.4] 2017-11-24
+## [0.12.4](https://github.com/pusher/pusher-platform-js/compare/0.12.3...0.12.4) - 2017-11-24
 
 ### Fixed
 
 - `fromXHR` in `ErrorResponse` now tries to `JSON.parse` the `responseText` from the `xhr` request to make errors easier to read
 
 
-## [v0.12.3] 2017-11-22
+## [0.12.3](https://github.com/pusher/pusher-platform-js/compare/0.12.2...0.12.3) - 2017-11-22
 
 ### Fixed
 
 - Call appropriate `onError` listener if `fetchToken` fails as part of a subscription
 
 
-## [v0.12.2] 2017-11-22
+## [0.12.2](https://github.com/pusher/pusher-platform-js/compare/0.12.1...0.12.2) - 2017-11-22
 
 ### Changes
 
 - Removed custom `XMLHttpRequest` and `WebSocket` and `Window` declarations and added `"webworker"` to `"lib"` in `tsconfig.json`
 
 
-## [v0.12.1] 2017-11-21
+## [0.12.1](https://github.com/pusher/pusher-platform-js/compare/0.12.0...0.12.1) - 2017-11-21
 
 ### Changes
 
 - Added `sendRawRequest` to allow service-specific SDKs to make requests without having to worry about networking setups themselves. `sendRawRequest` takes an `options` parameter of type `RawRequestOptions`
 
 
-## [v0.12.0] 2017-11-17
+## [0.12.0](https://github.com/pusher/pusher-platform-js/compare/0.11.1...0.12.0) - 2017-11-17
 
 ### Changes
 
@@ -112,24 +115,22 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 - Single index.d.ts declarations file no longer generated (removed dts-bundle as a dependency)
 
 
-## [v0.11.1] 2017-11-03
+## [0.11.1](https://github.com/pusher/pusher-platform-js/compare/0.11.0...0.11.1) - 2017-11-03
 
 ### Fixes
 
 - Treat all 2XX status codes as successful
 
-## [v0.11.0] 2017-11-03
+## [0.11.0](https://github.com/pusher/pusher-platform-js/compare/0.10.0...0.11.0) - 2017-11-03
 
 ### Changes
 
-This is quite big change since we added `websockets`
-as basic transport for all subscriptions. On the other
-hand there are no changes on public interfaces (library is using different transport internally).
+This is quite big change since we added `websockets` as basic transport for all subscriptions. On the other hand there are no changes on public interfaces (the SDK is using a different transport internally).
 
 - Added `websockets` as basic transport for all subscriptions
 - Separate `HTTP` related code into HTTP transport object
 
-## [v0.10.0] 2017-10-27
+## [0.10.0](https://github.com/pusher/pusher-platform-js/compare/0.9.2...0.10.0) - 2017-10-27
 
 ### Changes
 
@@ -140,17 +141,16 @@ hand there are no changes on public interfaces (library is using different trans
 
 - Default `logger` now set in `BaseClient` if `baseClient` without a `logger` is provided to the `Instance` constructor
 
-## [v0.9.2] 2017-10-06
+## [0.9.2](https://github.com/pusher/pusher-platform-js/compare/0.9.0...0.9.2) - 2017-10-06
 
 ### Fixes
 
 - Making authorized requests
 - Making authorized subscriptions
 
-## [v0.9.0] 2017-09-14
+## [0.9.0](https://github.com/pusher/pusher-platform-js/compare/0.7.0...0.9.0) - 2017-09-14
 
-Refactored a lot of stuff internally, some API changes. This is a big release.
-There will be an additional document describing how subscriptions are constructed, and how they work "under the hood".
+Refactored a lot of stuff internally, some API changes. This is a big release. There will be an additional document describing how subscriptions are constructed, and how they work "under the hood".
 
 ### Changes
 
@@ -171,21 +171,21 @@ There will be an additional document describing how subscriptions are constructe
 - `Logger` now can't be passed to each request anymore. It is now only created as part of `Instance` creation.
 - `Instance.request` now returns a `CancelablePromise` from `p-cancelable` library. It does not retry as of now.
 
-## [v0.7.0] 2017-07-19
+## [0.7.0](https://github.com/pusher/pusher-platform-js/compare/0.6.1...0.7.0) - 2017-07-19
 
 ### Changes
 
 - Renamed the `instance` to `instanceId` when instantiating an `Instance`. `Instance` class now has a parameter `id` that used to be `instance`.
 - Won the Internet for the most confusing changelog entries.
 
-## [v0.6.1] 2017-07-10
+## [0.6.1](https://github.com/pusher/pusher-platform-js/compare/0.6.0...0.6.1) - 2017-07-10
 
 ### Fixes
 
 - `ErrorResponse` `instanceof` now works correctly
 - `Retry-After` header is now handled correctly.
 
-## [v0.6.0] 2017-07-05
+## [0.6.0](https://github.com/pusher/pusher-platform-js/compare/0.5.2...0.6.0) - 2017-07-05
 
 ### Changes
 
@@ -193,4 +193,6 @@ There will be an additional document describing how subscriptions are constructe
 - Renamed `App` to `Instance`, `appId` to `instanceId`.
 - Updated the tenancy to the upcoming standard: https://cluster.and.host/services/serviceName/serviceVersion/instanceId/...
 
-_.. prehistory_
+---
+
+Older releases are not covered by this changelog.

--- a/src/transport/websocket.ts
+++ b/src/transport/websocket.ts
@@ -516,7 +516,12 @@ export default class WebSocketTransport implements SubscriptionTransport {
       );
     }
 
-    this.close();
+    const errorInfo = {
+      error: body.error || 'network_error',
+      error_description: body.error_description || 'Network error',
+    };
+
+    this.close(new ErrorResponse(statusCode, headers, errorInfo));
   }
 
   private onPongMessage(message: Message) {

--- a/test/integration/request_successful.test.js
+++ b/test/integration/request_successful.test.js
@@ -40,7 +40,7 @@ describe('Instance Requests - Successful', () => {
     instance
       .request({
         method: 'post',
-        path: 'post_ok',
+        path: 'post_ok_echo',
         json: {
           test: '123',
         },


### PR DESCRIPTION
### What?

Reconnect and retry as we should already be doing when a websocket receives a close message

### Why?

It wasn't working properly

### How?

Call `close(...)` with an `ErrorResponse` constructed from the close message body received from the server

----

CC @pusher/sigsdk