### PR TITLE
Make the websocket transport and subscriptions work reliably.

### DIFF
--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -37,8 +37,12 @@ export class BaseClient {
 
   constructor(private options: BaseClientOptions) {
     this.host = options.host.replace(/(\/)+$/, '');
-    this.logger = options.logger || new ConsoleLogger();
-    this.websocketTransport = new WebSocketTransport(this.host);
+    const logger = options.logger || new ConsoleLogger();
+    this.logger = logger;
+    this.websocketTransport = new WebSocketTransport(
+      this.host,
+      logger,
+    );
     this.httpTransport = new HttpTransport(this.host, options.encrypted);
     this.sdkProduct = options.sdkProduct || 'unknown';
     this.sdkVersion = options.sdkVersion || 'unknown';

--- a/src/network.ts
+++ b/src/network.ts
@@ -50,6 +50,10 @@ export class NetworkError {
   constructor(public error: string) {}
 }
 
+export class ProtocolError {
+  constructor(public error: string) {}
+}
+
 // Follows https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
 export enum XhrReadyState {
   UNSENT = 0,

--- a/src/retry-strategy.ts
+++ b/src/retry-strategy.ts
@@ -1,5 +1,9 @@
 import { Logger } from './logger';
-import { ErrorResponse, NetworkError } from './network';
+import {
+  ErrorResponse,
+  NetworkError,
+  ProtocolError,
+} from './network';
 
 export interface RetryStrategyOptions {
   increaseTimeout?: (currentTimeout: number) => number;
@@ -109,6 +113,10 @@ export class RetryResolution {
       return new DoNotRetry(error);
     }
 
+    if (error == null) {
+      return new Retry(this.calulateMillisToRetry());
+    }
+
     if (error instanceof ErrorResponse && error.headers['Retry-After']) {
       this.logger.verbose(
         `${this.constructor.name}: Retry-After header is present, retrying in ${
@@ -118,43 +126,45 @@ export class RetryResolution {
       return new Retry(parseInt(error.headers['Retry-After'], 10) * 1000);
     }
 
-    if (
-      error instanceof NetworkError ||
-      (error instanceof ErrorResponse &&
-        requestMethodIsSafe(error.headers['Request-Method'])) ||
-      this.retryUnsafeRequests
-    ) {
-      return this.shouldSafeRetry(error);
-    }
-    if (error instanceof NetworkError) {
-      return this.shouldSafeRetry(error);
+    if (this.retryUnsafeRequests) {
+      return new Retry(this.calulateMillisToRetry());
     }
 
-    this.logger.verbose(
-      `${this.constructor.name}: Error is not retryable`,
-      error,
-    );
-    return new DoNotRetry(error);
-  }
+    switch (error.constructor) {
+    case ErrorResponse:
+      const { statusCode, headers } = error;
+      const requestMethod = headers['Request-Method'];
 
-  private shouldSafeRetry(error: any) {
-    if (error instanceof NetworkError) {
+      if ((statusCode >= 500 && statusCode < 600) && requestMethodIsSafe(requestMethod)) {
+        this.logger.verbose(`${this.constructor.name}: Encountered an error with status code ${statusCode} and request method ${requestMethod}, will retry`);
+        return new Retry(this.calulateMillisToRetry());
+      } else {
+        this.logger.verbose(
+          `${this.constructor.name}: Encountered an error with status code ${statusCode} and request method ${requestMethod}, will not retry`,
+          error,
+        );
+        return new DoNotRetry(error as any);
+      }
+    case NetworkError:
       this.logger.verbose(
-        `${this.constructor.name}: It's a Network Error, will retry`,
+        `${this.constructor.name}: Encountered a network error, will retry`,
         error,
       );
       return new Retry(this.calulateMillisToRetry());
-    } else if (error instanceof ErrorResponse) {
-      if (error.statusCode >= 500 && error.statusCode < 600) {
-        this.logger.verbose(`${this.constructor.name}: Error 5xx, will retry`);
-        return new Retry(this.calulateMillisToRetry());
-      }
+    case ProtocolError:
+      this.logger.verbose(
+        `${this.constructor.name}: Encountered a protocol error, will retry`,
+        error,
+      );
+      return new Retry(this.calulateMillisToRetry());
+    default:
+      this.logger.verbose(
+        `${this.constructor.name}: Encountered an error, will retry`,
+        error,
+      );
+
+      return new Retry(this.calulateMillisToRetry());
     }
-    this.logger.verbose(
-      `${this.constructor.name}: Error is not retryable`,
-      error,
-    );
-    return new DoNotRetry(error);
   }
 
   private calulateMillisToRetry(): number {

--- a/src/transport/websocket.ts
+++ b/src/transport/websocket.ts
@@ -1,7 +1,9 @@
+import { Logger } from '../logger';
 import {
   ElementsHeaders,
   ErrorResponse,
   NetworkError,
+  ProtocolError,
   responseToHeadersObject,
 } from '../network';
 import {
@@ -120,10 +122,12 @@ export default class WebSocketTransport implements SubscriptionTransport {
   private pingInterval: any;
   private pongTimeout: any;
   private lastSentPingID: number | null;
+  private logger: Logger;
 
-  constructor(host: string) {
+  constructor(host: string, logger: Logger) {
     this.baseURL = `wss://${host}${this.webSocketPath}`;
     this.lastSubscriptionID = 0;
+    this.logger = logger;
     this.subscriptions = new WsSubscriptions();
     this.pendingSubscriptions = new WsSubscriptions();
 
@@ -207,7 +211,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
           }
 
           this.close(
-            new NetworkError(`Pong response wasn't received until timeout.`),
+            new NetworkError(`Pong response wasn't received within timeout`),
           );
         }, pingTimeoutMs);
       }, pingIntervalMs);
@@ -215,38 +219,26 @@ export default class WebSocketTransport implements SubscriptionTransport {
 
     this.socket.onmessage = (event: any) => this.receiveMessage(event);
     this.socket.onerror = (event: any) => {
-      this.close(new NetworkError('Connection was lost.'));
+      this.logger.verbose('WebSocket encountered an error event', event);
     };
     this.socket.onclose = (event: any) => {
-      if (!this.forcedClose) {
-        this.tryReconnectIfNeeded();
-        return;
-      }
+      this.logger.verbose('WebSocket encountered a close event', event);
 
-      const callback = this.closedError
-        ? (subscription: SubscriptionData) => {
-            if (subscription.listeners.onError) {
-              subscription.listeners.onError(this.closedError);
-            }
-          }
-        : (subscription: SubscriptionData) => {
-            if (subscription.listeners.onEnd) {
-              subscription.listeners.onEnd(null);
-            }
-          };
+      const subCallback = (subscription: SubscriptionData) => {
+        if (subscription.listeners.onError) {
+          subscription.listeners.onError(this.closedError);
+        }
+      }
 
       const allSubscriptions =
-        this.pendingSubscriptions.isEmpty() === false
-          ? this.pendingSubscriptions
-          : this.subscriptions;
+        this.pendingSubscriptions.isEmpty()
+          ? this.subscriptions
+          : this.pendingSubscriptions;
 
-      allSubscriptions.getAllAsArray().forEach(callback);
-
+      allSubscriptions.getAllAsArray().forEach(subCallback);
       allSubscriptions.removeAll();
 
-      if (this.closedError) {
-        this.tryReconnectIfNeeded();
-      }
+      this.tryReconnectIfNeeded();
     };
   }
 
@@ -259,13 +251,19 @@ export default class WebSocketTransport implements SubscriptionTransport {
     // websocket and the onclose method firing. When we're force closing the
     // connection we can expedite the reconnect process by manually calling
     // onclose. We then need to delete the socket's handlers so that we don't
-    // get extra calls from the dying socket.
+    // get extra calls from the dying socket. Calling bind here means we get
+    // a copy of the onclose callback, rather than a reference to it.
     const onClose = this.socket.onclose.bind(this);
 
-    delete this.socket.onclose;
-    delete this.socket.onerror;
-    delete this.socket.onmessage;
-    delete this.socket.onopen;
+    // Set all callbacks to be noops because we don't care about them anymore.
+    // We need to set the callbacks to new values because just calling delete
+    // doesn't seem to actually remove the property on the socket, and so
+    // the onclose callback would end up being called twice, leading to sad
+    // times.
+    this.socket.onclose = () => {};
+    this.socket.onerror = () => {};
+    this.socket.onmessage = () => {};
+    this.socket.onopen = () => {};
 
     this.forcedClose = true;
     this.closedError = error;
@@ -273,7 +271,8 @@ export default class WebSocketTransport implements SubscriptionTransport {
 
     global.clearTimeout(this.pingInterval);
     global.clearTimeout(this.pongTimeout);
-    delete this.pongTimeout;
+    this.pongTimeout = null;
+    this.pingInterval = null;
     this.lastSentPingID = null;
 
     onClose();
@@ -294,7 +293,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     subID?: number,
   ) {
     if (subID === undefined) {
-      global.console.log(`Subscription to path ${path} has an undefined ID`);
+      this.logger.debug(`Subscription to path ${path} has an undefined ID`);
       return;
     }
 
@@ -317,8 +316,8 @@ export default class WebSocketTransport implements SubscriptionTransport {
 
   private sendMessage(message: Message) {
     if (this.socket.readyState !== WSReadyState.Open) {
-      return global.console.warn(
-        `Can't send in "${WSReadyState[this.socket.readyState]}" state`,
+      return this.logger.warn(
+        `Can't send on socket in "${WSReadyState[this.socket.readyState]}" state`,
       );
     }
 
@@ -338,7 +337,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
       message = JSON.parse(event.data);
     } catch (err) {
       this.close(
-        new Error(`Message is not valid JSON format. Getting ${event.data}`),
+        new ProtocolError(`Message is not valid JSON format. Getting ${event.data}`),
       );
       return;
     }
@@ -347,7 +346,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     // Close connection if not valid.
     const nonValidMessageError = this.validateMessage(message);
     if (nonValidMessageError) {
-      this.close(new Error(nonValidMessageError.message));
+      this.close(nonValidMessageError);
       return;
     }
 
@@ -372,7 +371,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     if (!subscription) {
       this.close(
         new Error(
-          `Received message for non existing subscription id: "${subID}"`,
+          `Received message for unknown subscription ID: ${subID}`,
         ),
       );
       return;
@@ -392,7 +391,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
         this.onEOSMessage(message, subID, listeners);
         break;
       default:
-        this.close(new Error('Received non existing type of message.'));
+        this.close(new ProtocolError('Received non existing type of message.'));
     }
   }
 
@@ -401,9 +400,9 @@ export default class WebSocketTransport implements SubscriptionTransport {
    * @param message The message to check.
    * @returns null or error if the message is wrong.
    */
-  private validateMessage(message: Message): Error | null {
+  private validateMessage(message: Message): ProtocolError | null {
     if (!Array.isArray(message)) {
-      return new Error(
+      return new ProtocolError(
         `Message is expected to be an array. Getting: ${JSON.stringify(
           message,
         )}`,
@@ -411,7 +410,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     }
 
     if (message.length < 1) {
-      return new Error(`Message is empty array: ${JSON.stringify(message)}`);
+      return new ProtocolError(`Message is empty array: ${JSON.stringify(message)}`);
     }
 
     return null;
@@ -430,22 +429,22 @@ export default class WebSocketTransport implements SubscriptionTransport {
   private onEventMessage(
     eventMessage: Message,
     subscriptionListeners: SubscriptionListeners,
-  ): Error | void {
+  ) {
     if (eventMessage.length !== 3) {
-      return new Error(
+      new ProtocolError(
         'Event message has ' + eventMessage.length + ' elements (expected 4)',
       );
     }
 
     const [eventId, headers, body] = eventMessage;
     if (typeof eventId !== 'string') {
-      return new Error(
+      new ProtocolError(
         `Invalid event ID in message: ${JSON.stringify(eventMessage)}`,
       );
     }
 
     if (typeof headers !== 'object' || Array.isArray(headers)) {
-      return new Error(
+      new ProtocolError(
         `Invalid event headers in message: ${JSON.stringify(eventMessage)}`,
       );
     }
@@ -459,13 +458,13 @@ export default class WebSocketTransport implements SubscriptionTransport {
     eosMessage: Message,
     subID: number,
     subscriptionListeners: SubscriptionListeners,
-  ): void {
+  ) {
     this.subscriptions.remove(subID);
 
     if (eosMessage.length !== 3) {
       if (subscriptionListeners.onError) {
         subscriptionListeners.onError(
-          new Error(
+          new ProtocolError(
             `EOS message has ${eosMessage.length} elements (expected 4)`,
           ),
         );
@@ -476,14 +475,14 @@ export default class WebSocketTransport implements SubscriptionTransport {
     const [statusCode, headers, body] = eosMessage;
     if (typeof statusCode !== 'number') {
       if (subscriptionListeners.onError) {
-        subscriptionListeners.onError(new Error('Invalid EOS Status Code'));
+        subscriptionListeners.onError(new ProtocolError('Invalid EOS Status Code'));
       }
       return;
     }
 
     if (typeof headers !== 'object' || Array.isArray(headers)) {
       if (subscriptionListeners.onError) {
-        subscriptionListeners.onError(new Error('Invalid EOS ElementsHeaders'));
+        subscriptionListeners.onError(new ProtocolError('Invalid EOS ElementsHeaders'));
       }
       return;
     }
@@ -507,12 +506,12 @@ export default class WebSocketTransport implements SubscriptionTransport {
   private onCloseMessage(closeMessage: Message) {
     const [statusCode, headers, body] = closeMessage;
     if (typeof statusCode !== 'number') {
-      return this.close(new Error('Close message: Invalid EOS Status Code'));
+      return this.close(new ProtocolError('Close message: Invalid EOS Status Code'));
     }
 
     if (typeof headers !== 'object' || Array.isArray(headers)) {
       return this.close(
-        new Error('Close message: Invalid EOS ElementsHeaders'),
+        new ProtocolError('Close message: Invalid EOS ElementsHeaders'),
       );
     }
 
@@ -528,7 +527,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     const [receviedPongID] = message;
 
     if (this.lastSentPingID !== receviedPongID) {
-      global.console.warn(
+      this.logger.warn(
         `Received pong with ID ${receviedPongID} but lastSentPingID was ${
           this.lastSentPingID
         }`,


### PR DESCRIPTION
### What?

* Make WebSocket connections reliably reconnect.
* Make subscriptions reliably retry.

### Why?

It is good to have things retry when they are supposed to

### How?

Be more relaxed in terms of:

* retrying websocket connections
* retrying subscriptions 

Also just fix some bugs

---

One part I'm still not 100% sure on is this: https://github.com/pusher/pusher-platform-js/blob/1afa11afc461e49fd68aa224ca2f602082c701da/src/transport/websocket.ts#L233-L236

I'm not entirely sure why we perform the check to see if there are `pendingSubscriptions` and if there, use them as the subscriptions to call the `onError` callbacks on, otherwise call them on the `subscriptions`.

It seems like we could / should get rid of the check and just concat the two lists and call the callback on all of the resulting subscriptions. Reasonable?

----

CC @pusher/sigsdk