### PR TITLE
Stop closing the connection on unknown sub ID

### DIFF
--- a/src/transport/websocket.ts
+++ b/src/transport/websocket.ts
@@ -378,9 +378,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     const subscription = this.subscription(subID);
 
     if (!subscription) {
-      this.close(
-        new Error(`Received message for unknown subscription ID: ${subID}`),
-      );
+      this.logger.debug(`Received message for unknown subscription ID: ${subID}`);
       return;
     }
 


### PR DESCRIPTION
It is actually expected that the client could receive unknown
subscription IDs due to the following race condition:

 - Client closes a subscription
 - Simultaneously, the server sends a message for that subscription on
   the same connection.
 - The client gets a message for an unknown subscription.

### What?



### Why?



### How?



----

CC @pusher/sigsdk
