### PR TITLE
Backport unknown subscription fix to 0.14.x

### DIFF
--- a/src/transport/websocket.ts
+++ b/src/transport/websocket.ts
@@ -360,11 +360,7 @@ export default class WebSocketTransport implements SubscriptionTransport {
     const subscription = this.subscription(subID);
 
     if (!subscription) {
-      this.close(
-        new Error(
-          `Received message for non existing subscription id: "${subID}"`,
-        ),
-      );
+      global.console.logger.debug(`Received message for non existing subscription id: "${subID}"`);
       return;
     }
 


### PR DESCRIPTION
### What?
Backporting the fix for closed sub race conditions (https://github.com/pusher/pusher-platform-js/pull/94) to the 0.14.x line


### Why?
To fix the TextSync demo


### How?



----

CC @pusher/sigsdk
