### PR TITLE
Add an optional withCredentials options to sendRawRequest

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -25,6 +25,7 @@ export interface RawRequestOptions {
   url: string;
   headers?: ElementsHeaders;
   body?: any;
+  withCredentials?: boolean;
 }
 
 // TODO: Could we make this generic and remove the `any`s?
@@ -53,6 +54,7 @@ export function sendRawRequest(options: RawRequestOptions): Promise<any> {
       resolve,
       reject,
     );
+    xhr.withCredentials = Boolean(options.withCredentials);
 
     xhr.open(options.method.toUpperCase(), options.url, true);
 


### PR DESCRIPTION
### What?

Added a `withCredentials` option to `sendRawRequest` so that it can be used for cross-origin requests with credentials. Defaults to false.

### Why?

Chatkit's token provider uses `sendRawRequest` to contact token endpoints. If that endpoint lives under a different domain than the web app and requires cookies for auth, the current implementation won't work.

### How?



----

CC @pusher/sigsdk
