### PR TITLE
add sdkLanguage option to BaseClientOptions as optional override to X…

### DIFF
--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -21,6 +21,7 @@ export interface BaseClientOptions {
   host: string;
   encrypted?: boolean;
   logger?: Logger;
+  sdkLanguage?: string;
   sdkProduct?: string;
   sdkVersion?: string;
 }
@@ -33,6 +34,7 @@ export class BaseClient {
   private httpTransport: HttpTransport;
   private sdkProduct: string;
   private sdkVersion: string;
+  private sdkLanguage: string;
   private sdkPlatform: string;
 
   constructor(private options: BaseClientOptions) {
@@ -43,8 +45,11 @@ export class BaseClient {
     this.httpTransport = new HttpTransport(this.host, options.encrypted);
     this.sdkProduct = options.sdkProduct || 'unknown';
     this.sdkVersion = options.sdkVersion || 'unknown';
+    this.sdkLanguage = options.sdkLanguage || 'javascript';
     this.sdkPlatform = navigator
-      ? navigator.product === 'ReactNative' ? 'react-native' : 'web'
+      ? navigator.product === 'ReactNative'
+        ? 'react-native'
+        : 'web'
       : 'node';
   }
 
@@ -160,7 +165,7 @@ export class BaseClient {
 
   private infoHeaders(): { [key: string]: string } {
     return {
-      'X-SDK-Language': 'javascript',
+      'X-SDK-Language': this.sdkLanguage,
       'X-SDK-Platform': this.sdkPlatform,
       'X-SDK-Product': this.sdkProduct,
       'X-SDK-Version': this.sdkVersion,


### PR DESCRIPTION
…-SDK-Language header

We need to be able to set the language header to differentiate the React SDK from the vanilla JS SDK. I'm not totally sure the language header is the most appropriate one for this task, but our usage of the SDK headers is inconsistent as is, so this is the least worst easiest option.

A card calling for a full audit of the SDK headers at some point in the future has been created.

----

CC @pusher/sigsdk
